### PR TITLE
Add KEN embeddings correspondence table

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 Download and denormalization scripts for dirty_cat datasets.
 
 Contains also:
-- Correspondence table between KEN Embeddings (See #2) and their figshare download ID.
-- Happiness score dataset from the World Happiness Report 2022[[1]](#1).
+- Correspondence table between KEN Embeddings (See #1) and their figshare download ID.
+- Happiness score dataset from the World Happiness Report 2022[[1]](#2).
 
 ## References
 <a id="1">[1]</a>  
+https://soda-inria.github.io/ken_embeddings/
+<a id="2">[2]</a>  
 Helliwell, J. F., Layard, R., Sachs, J. D., De Neve, J.-E., Aknin, L. B., & Wang, S. (Eds.). (2022). 
 [World Happiness Report 2022](https://worldhappiness.report/ed/2022/). New York: Sustainable Development Solutions Network.
-<a id="2">[2]</a>  
-https://soda-inria.github.io/ken_embeddings/

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 Download and denormalization scripts for dirty_cat datasets.
 
 Contains also:
-- Correspondence table between KEN Embeddings and their figshare download ID. 
+- Correspondence table between KEN Embeddings (See #2) and their figshare download ID.
 - Happiness score dataset from the World Happiness Report 2022[[1]](#1).
 
 ## References
 <a id="1">[1]</a>  
 Helliwell, J. F., Layard, R., Sachs, J. D., De Neve, J.-E., Aknin, L. B., & Wang, S. (Eds.). (2022). 
 [World Happiness Report 2022](https://worldhappiness.report/ed/2022/). New York: Sustainable Development Solutions Network.
+<a id="2">[2]</a>  
+https://soda-inria.github.io/ken_embeddings/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Datasets
 Download and denormalization scripts for dirty_cat datasets.
 
-Contains also the Happiness score from the World Happiness Report 2022[[1]](#1).
+Contains also:
+- Correspondence table between KEN Embeddings and their figshare download ID. 
+- Happiness score dataset from the World Happiness Report 2022[[1]](#1).
 
 ## References
 <a id="1">[1]</a>  

--- a/data/ken_correspondence.csv
+++ b/data/ken_correspondence.csv
@@ -1,0 +1,7 @@
+table,entities_figshare_id,type_figshare_id
+all_entities,39142985,39266300
+albums,39149066,39268592
+companies,39149072,39268592
+movies,39149069,39268592
+games,39254360,39266678
+schools,39149075,39268592


### PR DESCRIPTION
Add correspondence between the Wikipedia embeddings and their respective figshare id needed for fetching.